### PR TITLE
Add grid mapping utilities with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,21 @@ python scripts/simulation/run_simulation.py
 
 The sample script spawns a plane and an R2D2 robot model to validate that the
 simulation environment is properly configured.
+
+## Mapping Utilities
+
+The `mapping` package contains simple grid data structures useful for testing navigation algorithms.
+
+```python
+from mapping.occupancy_grid import OccupancyGrid
+
+# Create a 10x10 grid with 0.1m resolution
+grid = OccupancyGrid(width=10, height=10, resolution=0.1)
+
+# Mark a cell as occupied
+grid.set_cell(5, 5, 1)
+
+# Convert to a probability map
+prob_map = grid.to_probability_map()
+print(prob_map.get_cell(5, 5))  # 1.0
+```

--- a/environment/requirements.txt
+++ b/environment/requirements.txt
@@ -1,3 +1,4 @@
 pybullet
+numpy
 
 networkx

--- a/src/mapping/occupancy_grid.py
+++ b/src/mapping/occupancy_grid.py
@@ -1,0 +1,28 @@
+import numpy as np
+from dataclasses import dataclass, field
+
+@dataclass
+class OccupancyGrid:
+    width: int
+    height: int
+    resolution: float
+    default_value: int = 0
+    grid: np.ndarray = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.grid = np.full((self.height, self.width), self.default_value, dtype=int)
+
+    def get_cell(self, x: int, y: int) -> int:
+        return int(self.grid[y, x])
+
+    def set_cell(self, x: int, y: int, value: int) -> None:
+        self.grid[y, x] = int(value)
+
+    def reset(self, value: int = 0) -> None:
+        self.grid.fill(int(value))
+
+    def to_probability_map(self) -> 'ProbabilityMap':
+        from .probability_map import ProbabilityMap
+        prob = self.grid.astype(float)
+        prob[prob != 0] = 1.0
+        return ProbabilityMap(self.width, self.height, self.resolution, grid=prob)

--- a/src/mapping/probability_map.py
+++ b/src/mapping/probability_map.py
@@ -1,0 +1,32 @@
+import numpy as np
+from dataclasses import dataclass, field
+
+@dataclass
+class ProbabilityMap:
+    width: int
+    height: int
+    resolution: float
+    default_value: float = 0.0
+    grid: np.ndarray = field(default=None)
+
+    def __post_init__(self) -> None:
+        if self.grid is None:
+            self.grid = np.full((self.height, self.width), self.default_value, dtype=float)
+        else:
+            self.grid = self.grid.astype(float)
+
+    def get_cell(self, x: int, y: int) -> float:
+        return float(self.grid[y, x])
+
+    def set_cell(self, x: int, y: int, value: float) -> None:
+        self.grid[y, x] = float(value)
+
+    def reset(self, value: float = 0.0) -> None:
+        self.grid.fill(float(value))
+
+    def to_occupancy_grid(self, threshold: float = 0.5) -> 'OccupancyGrid':
+        from .occupancy_grid import OccupancyGrid
+        occ = (self.grid >= threshold).astype(int)
+        grid = OccupancyGrid(self.width, self.height, self.resolution)
+        grid.grid = occ
+        return grid

--- a/tests/unit/test_mapping.py
+++ b/tests/unit/test_mapping.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+
+SRC_PATH = Path(__file__).resolve().parents[2] / 'src'
+sys.path.append(str(SRC_PATH))
+
+from mapping.occupancy_grid import OccupancyGrid
+from mapping.probability_map import ProbabilityMap
+
+
+def test_occupancy_grid_init_and_set():
+    grid = OccupancyGrid(width=3, height=2, resolution=1.0, default_value=0)
+    assert grid.grid.shape == (2, 3)
+    assert grid.get_cell(1, 1) == 0
+    grid.set_cell(1, 1, 1)
+    assert grid.get_cell(1, 1) == 1
+
+
+def test_probability_map_conversion():
+    occ = OccupancyGrid(width=2, height=2, resolution=0.5)
+    occ.set_cell(0, 0, 1)
+    pmap = occ.to_probability_map()
+    assert pmap.get_cell(0, 0) == 1.0
+    assert pmap.get_cell(1, 1) == 0.0
+    occ2 = pmap.to_occupancy_grid()
+    assert occ2.get_cell(0, 0) == 1
+    assert occ2.get_cell(1, 1) == 0


### PR DESCRIPTION
## Summary
- introduce OccupancyGrid and ProbabilityMap for representing map data
- include unit tests for basic grid operations
- document mapping usage in the README
- update requirements with numpy

## Testing
- `pip install -r environment/requirements.txt`
- `pip install numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68594237577883259716d231eb5ad3d5