### PR TITLE
Add ground truth heatmap generation

### DIFF
--- a/scripts/data_generation/generate_ground_truth.py
+++ b/scripts/data_generation/generate_ground_truth.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Generate ground truth heatmaps from occupancy grid files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from functools import partial
+from multiprocessing import Pool
+from pathlib import Path
+import sys
+
+import numpy as np
+
+SRC_PATH = Path(__file__).resolve().parents[2] / 'src'
+sys.path.append(str(SRC_PATH))
+
+from data_generation.ground_truth_heatmaps import (
+    PRMConfig,
+    HeatmapConfig,
+    generate_heatmap,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate utility heatmaps")
+    parser.add_argument("--input-dir", type=str, required=True)
+    parser.add_argument("--output-dir", type=str, required=True)
+    parser.add_argument("--config", type=str, default=None)
+    parser.add_argument("--samples", type=int, default=500)
+    parser.add_argument("--radius", type=float, default=10.0)
+    parser.add_argument("--top-k", type=int, default=50)
+    parser.add_argument("--sigma", type=float, default=2.0)
+    parser.add_argument("--method", type=str, choices=["betweenness", "component"], default="betweenness")
+    parser.add_argument("--processes", type=int, default=1)
+    parser.add_argument("--overlay", action="store_true")
+    return parser.parse_args()
+
+
+def load_config(path: Path) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+def save_overlay(grid: np.ndarray, heatmap: np.ndarray, out_path: Path) -> None:
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return
+    plt.imshow(grid, cmap="gray", origin="lower")
+    plt.imshow(heatmap, cmap="hot", origin="lower", alpha=0.5)
+    plt.axis("off")
+    plt.savefig(out_path, bbox_inches="tight")
+    plt.close()
+
+
+def process_file(file_path: Path, out_dir: Path, prm_cfg: PRMConfig, hm_cfg: HeatmapConfig, method: str, overlay: bool) -> None:
+    grid = np.load(file_path)
+    heatmap = generate_heatmap(grid, prm_cfg, hm_cfg, method)
+    out_file = out_dir / file_path.name.replace("env_", "gt_")
+    np.save(out_file, heatmap)
+    if overlay:
+        img_file = out_file.with_suffix(".png")
+        save_overlay(grid, heatmap, img_file)
+
+
+def main() -> None:
+    args = parse_args()
+    cfg = {}
+    if args.config:
+        cfg = load_config(Path(args.config))
+    input_dir = Path(args.input_dir)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    prm_cfg = PRMConfig(num_samples=cfg.get("samples", args.samples), radius=cfg.get("radius", args.radius))
+    hm_cfg = HeatmapConfig(sigma=cfg.get("sigma", args.sigma), top_k=cfg.get("top_k", args.top_k))
+    method = cfg.get("method", args.method)
+
+    files = sorted(input_dir.glob("*.npy"))
+    worker = partial(process_file, out_dir=output_dir, prm_cfg=prm_cfg, hm_cfg=hm_cfg, method=method, overlay=args.overlay)
+    if args.processes > 1:
+        with Pool(args.processes) as pool:
+            list(pool.imap_unordered(worker, files))
+    else:
+        for f in files:
+            worker(f)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data_generation/ground_truth_heatmaps.py
+++ b/src/data_generation/ground_truth_heatmaps.py
@@ -1,0 +1,139 @@
+"""Utility functions for generating heatmaps from occupancy grids."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+import math
+
+import numpy as np
+import networkx as nx
+
+
+@dataclass
+class PRMConfig:
+    """Configuration for probabilistic roadmap generation."""
+
+    num_samples: int = 500
+    radius: float = 10.0
+
+
+@dataclass
+class HeatmapConfig:
+    """Configuration for heatmap generation."""
+
+    sigma: float = 2.0
+    top_k: int = 50
+
+
+def _sample_free_points(grid: np.ndarray, num_samples: int) -> List[Tuple[int, int]]:
+    free = np.argwhere(grid == 0)
+    if len(free) == 0:
+        return []
+    idx = np.random.choice(len(free), size=min(num_samples, len(free)), replace=False)
+    pts = [(int(y), int(x)) for y, x in free[idx]]
+    return pts
+
+
+def _bresenham_line(x0: int, y0: int, x1: int, y1: int) -> Iterable[Tuple[int, int]]:
+    """Yield coordinates of cells on a line using Bresenham algorithm."""
+    dx = abs(x1 - x0)
+    dy = -abs(y1 - y0)
+    sx = 1 if x0 < x1 else -1
+    sy = 1 if y0 < y1 else -1
+    err = dx + dy
+    while True:
+        yield x0, y0
+        if x0 == x1 and y0 == y1:
+            break
+        e2 = 2 * err
+        if e2 >= dy:
+            err += dy
+            x0 += sx
+        if e2 <= dx:
+            err += dx
+            y0 += sy
+
+
+def _collision_free(grid: np.ndarray, p: Tuple[int, int], q: Tuple[int, int]) -> bool:
+    for x, y in _bresenham_line(p[0], p[1], q[0], q[1]):
+        if grid[y, x] != 0:
+            return False
+    return True
+
+
+def build_prm(grid: np.ndarray, config: PRMConfig) -> nx.Graph:
+    """Build a simple PRM directly on the occupancy grid."""
+    points = _sample_free_points(grid, config.num_samples)
+    G = nx.Graph()
+    for idx, (y, x) in enumerate(points):
+        G.add_node(idx, pos=(x, y))
+    for i, (y1, x1) in enumerate(points):
+        for j in range(i + 1, len(points)):
+            y2, x2 = points[j]
+            if math.hypot(x1 - x2, y1 - y2) <= config.radius and _collision_free(
+                grid, (x1, y1), (x2, y2)
+            ):
+                G.add_edge(i, j, weight=math.hypot(x1 - x2, y1 - y2))
+    return G
+
+
+def betweenness_high_utility_nodes(G: nx.Graph, top_k: int) -> List[Tuple[int, int]]:
+    if G.number_of_nodes() == 0:
+        return []
+    centrality = nx.betweenness_centrality(G)
+    sorted_nodes = sorted(centrality.items(), key=lambda x: x[1], reverse=True)
+    return [G.nodes[n]["pos"][::-1] for n, _ in sorted_nodes[:top_k]]
+
+
+def largest_component_nodes(G: nx.Graph) -> List[Tuple[int, int]]:
+    if G.number_of_nodes() == 0:
+        return []
+    components = list(nx.connected_components(G))
+    if not components:
+        return []
+    largest = max(components, key=len)
+    return [G.nodes[n]["pos"][::-1] for n in largest]
+
+
+def _gaussian_kernel(sigma: float) -> np.ndarray:
+    size = max(1, int(6 * sigma + 1))
+    if size % 2 == 0:
+        size += 1
+    ax = np.arange(-size // 2 + 1, size // 2 + 1)
+    kernel1d = np.exp(-(ax**2) / (2 * sigma**2))
+    kernel1d = kernel1d / kernel1d.sum()
+    kernel2d = np.outer(kernel1d, kernel1d)
+    return kernel2d / kernel2d.sum()
+
+
+def nodes_to_heatmap(points: Iterable[Tuple[int, int]], shape: Tuple[int, int], sigma: float) -> np.ndarray:
+    heatmap = np.zeros(shape, dtype=float)
+    kernel = _gaussian_kernel(sigma)
+    k_half = kernel.shape[0] // 2
+    h, w = shape
+    for y, x in points:
+        x0 = int(round(x))
+        y0 = int(round(y))
+        x_start = max(0, x0 - k_half)
+        x_end = min(w, x0 + k_half + 1)
+        y_start = max(0, y0 - k_half)
+        y_end = min(h, y0 + k_half + 1)
+        kx_start = x_start - (x0 - k_half)
+        kx_end = kx_start + (x_end - x_start)
+        ky_start = y_start - (y0 - k_half)
+        ky_end = ky_start + (y_end - y_start)
+        heatmap[y_start:y_end, x_start:x_end] += kernel[ky_start:ky_end, kx_start:kx_end]
+    if heatmap.max() > 0:
+        heatmap = heatmap / heatmap.max()
+    return heatmap
+
+
+def generate_heatmap(grid: np.ndarray, prm_cfg: PRMConfig, hm_cfg: HeatmapConfig, method: str = "betweenness") -> np.ndarray:
+    graph = build_prm(grid, prm_cfg)
+    if method == "betweenness":
+        points = betweenness_high_utility_nodes(graph, hm_cfg.top_k)
+    else:
+        points = largest_component_nodes(graph)
+    return nodes_to_heatmap(points, grid.shape, hm_cfg.sigma)
+

--- a/tests/unit/test_ground_truth_heatmap.py
+++ b/tests/unit/test_ground_truth_heatmap.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import sys
+
+import numpy as np
+
+SRC_PATH = Path(__file__).resolve().parents[2] / 'src'
+sys.path.append(str(SRC_PATH))
+
+from data_generation.ground_truth_heatmaps import (
+    PRMConfig,
+    HeatmapConfig,
+    build_prm,
+    betweenness_high_utility_nodes,
+    largest_component_nodes,
+    nodes_to_heatmap,
+)
+
+
+def test_prm_and_betweenness():
+    grid = np.zeros((20, 20), dtype=np.uint8)
+    grid[5:15, 10] = 1
+    prm = build_prm(grid, PRMConfig(num_samples=40, radius=5))
+    points = betweenness_high_utility_nodes(prm, top_k=5)
+    assert len(points) <= 5
+    for y, x in points:
+        assert 0 <= x < grid.shape[1]
+        assert 0 <= y < grid.shape[0]
+
+
+def test_largest_component_nodes():
+    grid = np.zeros((20, 20), dtype=np.uint8)
+    grid[10:, :] = 1
+    prm = build_prm(grid, PRMConfig(num_samples=30, radius=4))
+    pts = largest_component_nodes(prm)
+    assert all(len(p) == 2 for p in pts)
+
+
+def test_nodes_to_heatmap():
+    shape = (10, 10)
+    points = [(5, 5), (2, 2)]
+    heatmap = nodes_to_heatmap(points, shape, sigma=1.0)
+    assert heatmap.shape == shape
+    assert heatmap.max() <= 1.0
+    assert heatmap.min() >= 0.0


### PR DESCRIPTION
## Summary
- implement occupancy grid processing utilities in `ground_truth_heatmaps.py`
- add CLI script `generate_ground_truth.py` to create heatmaps
- test PRM, graph analysis, and heatmap generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a724544208325948929197c4ebe3e