### PR TITLE
Implement config-driven training data generation

### DIFF
--- a/configs/data_generation/sample_training_data.yaml
+++ b/configs/data_generation/sample_training_data.yaml
@@ -1,0 +1,23 @@
+seed: 42
+output_dir: data/training_samples
+num_maps: 2
+samples_per_map: 2
+map_resolution: 200
+shell_thickness: 2
+bsp:
+  min_leaf_size: 30
+  split_range: [0.4, 0.6]
+  wall_thickness: 2
+doors:
+  width_range: [3, 5]
+obstacles:
+  count_range_per_room: [1, 3]
+  door_clearance: 2
+  shape_definitions:
+    - size_range: [2, 6]
+      weight: 1.0
+robots:
+  - clearance: 0.2
+    step_size: 1.0
+  - clearance: 0.3
+    step_size: 1.5

--- a/copilot/tests/main.py
+++ b/copilot/tests/main.py
@@ -1,0 +1,2 @@
+def main():
+    print('Hybrid Robot Navigation System: Hello, World!')

--- a/main.py
+++ b/main.py
@@ -1,0 +1,4 @@
+from copilot.main import main
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data_generation/generate_training_data.py
+++ b/scripts/data_generation/generate_training_data.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Generate training samples using a YAML configuration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List
+import random
+
+import numpy as np
+import yaml
+
+SRC_PATH = Path(__file__).resolve().parents[2] / 'src'
+import sys
+sys.path.append(str(SRC_PATH))
+
+from data_generation.office_map_generator import (
+    generate_office_map,
+    flood_fill_connected,
+)
+
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s:%(message)s')
+
+
+def load_config(path: Path) -> Dict:
+    with open(path, 'r') as f:
+        return yaml.safe_load(f)
+
+
+def choose_free_cell(grid: np.ndarray, rng: random.Random) -> tuple[int, int]:
+    free = np.argwhere(grid == 0)
+    idx = rng.randint(0, len(free) - 1)
+    y, x = free[idx]
+    return int(y), int(x)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Generate training data')
+    parser.add_argument('--config', type=str, required=True)
+    args = parser.parse_args()
+
+    cfg = load_config(Path(args.config))
+    seed = int(cfg.get('seed', 0))
+    rng = random.Random(seed)
+    np.random.seed(seed)
+
+    out_dir = Path(cfg.get('output_dir', 'data/training_samples'))
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    num_maps = int(cfg.get('num_maps', 1))
+    samples_per_map = int(cfg.get('samples_per_map', 1))
+    robots: List[Dict] = cfg.get('robots', [{'clearance': 0.2, 'step_size': 1.0}])
+
+    for map_idx in range(num_maps):
+        logging.info('Generating map %d/%d', map_idx + 1, num_maps)
+        base = generate_office_map(cfg, rng)
+        if not flood_fill_connected(base):
+            logging.warning('Map %d is not fully connected', map_idx)
+        for sample_idx in range(samples_per_map):
+            for robot_idx, robot in enumerate(robots):
+                sample = base.copy()
+                sy, sx = choose_free_cell(sample, rng)
+                gy, gx = choose_free_cell(sample, rng)
+                while (gy, gx) == (sy, sx):
+                    gy, gx = choose_free_cell(sample, rng)
+                sample[sy, sx] = 2
+                sample[gy, gx] = 3
+                name = f'map{map_idx:04d}_s{sample_idx:02d}_r{robot_idx:02d}.npz'
+                out_path = out_dir / name
+                np.savez_compressed(
+                    out_path,
+                    map=sample,
+                    clearance=float(robot.get('clearance', 0.2)),
+                    step_size=float(robot.get('step_size', 1.0)),
+                    config=json.dumps(cfg),
+                )
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/utils/visualize_training_sample.py
+++ b/scripts/utils/visualize_training_sample.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Visualize a generated training sample in PyBullet."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pybullet as p
+import pybullet_data
+
+
+def load_sample(path: Path) -> dict:
+    return dict(np.load(path, allow_pickle=True))
+
+
+def render_sample(data: dict) -> None:
+    grid = data['map']
+    res = grid.shape[0]
+    cell = 0.05
+    half = res * cell / 2.0
+
+    p.connect(p.GUI)
+    p.setAdditionalSearchPath(pybullet_data.getDataPath())
+    p.loadURDF('plane.urdf')
+
+    box_col = p.createCollisionShape(p.GEOM_BOX, halfExtents=[cell / 2] * 3)
+    box_vis = p.createVisualShape(p.GEOM_BOX, halfExtents=[cell / 2] * 3, rgbaColor=[0.6, 0.6, 0.6, 1])
+    start_vis = p.createVisualShape(p.GEOM_SPHERE, radius=cell / 2, rgbaColor=[0, 1, 0, 1])
+    goal_vis = p.createVisualShape(p.GEOM_SPHERE, radius=cell / 2, rgbaColor=[1, 0, 0, 1])
+
+    for y in range(res):
+        for x in range(res):
+            val = int(grid[y, x])
+            pos = [x * cell - half + cell / 2, y * cell - half + cell / 2, cell / 2]
+            if val == 1:
+                p.createMultiBody(0, box_col, box_vis, pos)
+            elif val == 2:
+                p.createMultiBody(0, -1, start_vis, pos)
+            elif val == 3:
+                p.createMultiBody(0, -1, goal_vis, pos)
+
+    while p.isConnected():
+        p.stepSimulation()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Visualize a training sample')
+    parser.add_argument('file', type=str)
+    args = parser.parse_args()
+
+    data = load_sample(Path(args.file))
+    render_sample(data)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/data_generation/__init__.py
+++ b/src/data_generation/__init__.py
@@ -1,0 +1,4 @@
+from .office_map_generator import (
+    generate_office_map,
+    flood_fill_connected,
+)

--- a/src/data_generation/office_map_generator.py
+++ b/src/data_generation/office_map_generator.py
@@ -1,0 +1,153 @@
+"""Procedural office-like map generation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+import random
+import numpy as np
+
+
+@dataclass
+class Leaf:
+    """Leaf node of the BSP tree."""
+
+    x: int
+    y: int
+    w: int
+    h: int
+
+
+@dataclass
+class Wall:
+    orientation: str  # 'v' or 'h'
+    pos: int
+    start: int
+    end: int
+
+
+def bsp_partition(width: int, height: int, cfg: Dict, rng: random.Random) -> Tuple[List[Leaf], List[Wall]]:
+    """Generate a BSP layout returning rooms and dividing walls."""
+    min_leaf = int(cfg.get("min_leaf_size", 20))
+    split_low, split_high = cfg.get("split_range", [0.4, 0.6])
+
+    leaves: List[Leaf] = [Leaf(0, 0, width, height)]
+    walls: List[Wall] = []
+    queue = [0]
+    while queue:
+        idx = queue.pop()
+        leaf = leaves[idx]
+        if leaf.w < 2 * min_leaf and leaf.h < 2 * min_leaf:
+            continue
+        split_vert = leaf.w > leaf.h
+        if leaf.w >= 2 * min_leaf and leaf.h >= 2 * min_leaf:
+            split_vert = rng.random() < 0.5
+        if split_vert:
+            min_split = int(leaf.w * split_low)
+            max_split = int(leaf.w * split_high)
+            if max_split - min_split < min_leaf:
+                continue
+            split = rng.randint(min_split, max_split)
+            left = Leaf(leaf.x, leaf.y, split, leaf.h)
+            right = Leaf(leaf.x + split, leaf.y, leaf.w - split, leaf.h)
+            leaves[idx] = left
+            leaves.append(right)
+            queue.append(len(leaves) - 1)
+            queue.append(idx)
+            walls.append(Wall('v', leaf.x + split, leaf.y, leaf.y + leaf.h))
+        else:
+            min_split = int(leaf.h * split_low)
+            max_split = int(leaf.h * split_high)
+            if max_split - min_split < min_leaf:
+                continue
+            split = rng.randint(min_split, max_split)
+            top = Leaf(leaf.x, leaf.y, leaf.w, split)
+            bottom = Leaf(leaf.x, leaf.y + split, leaf.w, leaf.h - split)
+            leaves[idx] = top
+            leaves.append(bottom)
+            queue.append(len(leaves) - 1)
+            queue.append(idx)
+            walls.append(Wall('h', leaf.y + split, leaf.x, leaf.x + leaf.w))
+    return leaves, walls
+
+
+def apply_walls(grid: np.ndarray, walls: List[Wall], wall_thickness: int, door_cfg: Dict, rng: random.Random) -> None:
+    """Draw walls and doorways onto the grid."""
+    half = wall_thickness // 2
+    for wall in walls:
+        door_min, door_max = door_cfg.get("width_range", [3, 5])
+        door_width = rng.randint(door_min, door_max)
+        if wall.orientation == 'v':
+            y0, y1 = wall.start, wall.end
+            x = wall.pos
+            grid[y0:y1, max(0, x - half):min(grid.shape[1], x + half + 1)] = 1
+            door_y = rng.randint(y0 + half + 1, max(y0 + half + 1, y1 - half - door_width))
+            grid[door_y:door_y + door_width, max(0, x - half):min(grid.shape[1], x + half + 1)] = 0
+        else:
+            x0, x1 = wall.start, wall.end
+            y = wall.pos
+            grid[max(0, y - half):min(grid.shape[0], y + half + 1), x0:x1] = 1
+            door_x = rng.randint(x0 + half + 1, max(x0 + half + 1, x1 - half - door_width))
+            grid[max(0, y - half):min(grid.shape[0], y + half + 1), door_x:door_x + door_width] = 0
+
+
+def place_obstacles(grid: np.ndarray, rooms: List[Leaf], cfg: Dict, wall_thickness: int, rng: random.Random) -> None:
+    count_min, count_max = cfg.get("count_range_per_room", [0, 0])
+    door_clearance = int(cfg.get("door_clearance", 1))
+    shape_defs = cfg.get("shape_definitions", [{"size_range": [2, 4], "weight": 1.0}])
+    weights = [sd.get("weight", 1.0) for sd in shape_defs]
+    for room in rooms:
+        num = rng.randint(count_min, count_max + 1)
+        for _ in range(num):
+            shape_def = rng.choices(shape_defs, weights)[0]
+            size_min, size_max = shape_def.get("size_range", [2, 4])
+            size = rng.randint(size_min, size_max)
+            for _ in range(10):
+                x = rng.randint(room.x + wall_thickness, room.x + room.w - size - wall_thickness)
+                y = rng.randint(room.y + wall_thickness, room.y + room.h - size - wall_thickness)
+                patch = grid[y - door_clearance:y + size + door_clearance, x - door_clearance:x + size + door_clearance]
+                if np.all(patch == 0):
+                    grid[y:y + size, x:x + size] = 1
+                    break
+
+
+def flood_fill_connected(grid: np.ndarray) -> bool:
+    """Check if free space is a single connected component."""
+    free = np.argwhere(grid == 0)
+    if len(free) == 0:
+        return False
+    start = tuple(free[0])
+    visited = np.zeros_like(grid, dtype=bool)
+    stack = [start]
+    visited[start] = True
+    while stack:
+        cy, cx = stack.pop()
+        for dy, dx in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+            ny, nx = cy + dy, cx + dx
+            if 0 <= ny < grid.shape[0] and 0 <= nx < grid.shape[1]:
+                if not visited[ny, nx] and grid[ny, nx] == 0:
+                    visited[ny, nx] = True
+                    stack.append((ny, nx))
+    return visited[grid == 0].all()
+
+
+def generate_office_map(cfg: Dict, rng: random.Random) -> np.ndarray:
+    resolution = int(cfg.get("map_resolution", 200))
+    shell = int(cfg.get("shell_thickness", 2))
+    wall_thickness = int(cfg.get("bsp", {}).get("wall_thickness", 2))
+
+    grid = np.zeros((resolution, resolution), dtype=np.uint8)
+    grid[:shell, :] = 1
+    grid[-shell:, :] = 1
+    grid[:, :shell] = 1
+    grid[:, -shell:] = 1
+
+    rooms, walls = bsp_partition(resolution - 2 * shell, resolution - 2 * shell, cfg.get("bsp", {}), rng)
+    shifted_rooms = [Leaf(r.x + shell, r.y + shell, r.w, r.h) for r in rooms]
+    shifted_walls = [Wall(w.orientation, w.pos + shell if w.orientation == 'v' else w.pos + shell, w.start + shell, w.end + shell) for w in walls]
+
+    apply_walls(grid, shifted_walls, wall_thickness, cfg.get("doors", {}), rng)
+    place_obstacles(grid, shifted_rooms, cfg.get("obstacles", {}), wall_thickness, rng)
+
+    return grid
+


### PR DESCRIPTION
## Summary
- create a simple office-style map generator
- expose generator functions in data_generation package
- add training data generation script
- provide visualization utility
- supply example YAML config
- add wrapper main for tests
- include helper main module in tests

## Testing
- `pytest -q`
- `python scripts/data_generation/generate_training_data.py --config configs/data_generation/sample_training_data.yaml | head`

------
https://chatgpt.com/codex/tasks/task_e_685d48d874e88325bd74d83c1b32be16