### PR TITLE
Fix axis overlay in visualizer

### DIFF
--- a/scripts/utils/visualize_training_sample.py
+++ b/scripts/utils/visualize_training_sample.py
@@ -105,6 +105,11 @@ def main() -> None:
         sample_file = select_sample_with_dialog(args.dir)
 
     p.connect(p.GUI)
+    # Hide the default axis/GUI overlay for a cleaner view
+    try:
+        p.configureDebugVisualizer(p.COV_ENABLE_GUI, 0)
+    except Exception:
+        pass
     load_and_render(sample_file)
     print("Press 'S' to select a new environment, or close the window to exit.")
     pulse_angle = 0


### PR DESCRIPTION
## Summary
- hide pybullet axis overlay in `visualize_training_sample.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pybullet', 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685e9fb38644832598ee23bb65e515e2