### PR TITLE
Improve error handling in ground truth script

### DIFF
--- a/scripts/data_generation/generate_ground_truth.py
+++ b/scripts/data_generation/generate_ground_truth.py
@@ -14,6 +14,12 @@ from typing import Tuple
 
 import numpy as np
 
+
+class GroundTruthGenerationError(RuntimeError):
+    """Raised when ground truth generation fails."""
+
+    pass
+
 SRC_PATH = Path(__file__).resolve().parents[2] / 'src'
 sys.path.append(str(SRC_PATH))
 
@@ -40,31 +46,67 @@ def parse_args() -> argparse.Namespace:
 
 
 def load_npz(file_path: Path):
-    data = np.load(file_path, allow_pickle=True)
-    grid = data['map']
-    c = float(data['clearance'])
-    s = float(data['step_size'])
+    """Load a training sample from an ``npz`` file with validation."""
+    if not file_path.exists():
+        raise GroundTruthGenerationError(
+            f"load_npz: file not found -> {file_path}")
+    try:
+        data = np.load(file_path, allow_pickle=True)
+    except Exception as exc:
+        raise GroundTruthGenerationError(
+            f"load_npz: failed to read {file_path}: {exc}") from exc
+
+    required = {"map", "clearance", "step_size"}
+    missing = required.difference(data.files)
+    if missing:
+        raise GroundTruthGenerationError(
+            f"load_npz: missing keys {missing} in {file_path}")
+
+    grid = data["map"]
+    c = float(data["clearance"])
+    s = float(data["step_size"])
     return grid, c, s
 
 
 def preprocess_map(map_id: str, grid: np.ndarray, num_samples: int, k: int):
-    dist_path = CACHE_DIR / f'{map_id}_dist.npy'
-    prm_path = CACHE_DIR / f'{map_id}_prm.pkl'
+    """Compute and cache distance transform and PRM for a map."""
+    if grid.size == 0:
+        raise GroundTruthGenerationError(
+            f"preprocess_map: empty grid for map_id={map_id}")
+    dist_path = CACHE_DIR / f"{map_id}_dist.npy"
+    prm_path = CACHE_DIR / f"{map_id}_prm.pkl"
     if dist_path.exists() and prm_path.exists():
-        dist = np.load(dist_path)
-        with open(prm_path, 'rb') as f:
-            prm = pickle.load(f)
+        try:
+            dist = np.load(dist_path)
+            with open(prm_path, "rb") as f:
+                prm = pickle.load(f)
+        except Exception as exc:
+            raise GroundTruthGenerationError(
+                f"preprocess_map: failed to load cache for {map_id}: {exc}") from exc
         return dist, prm
-    dist = distance_transform((grid != 0).astype(np.uint8))
-    prm = build_prm((grid != 0).astype(np.uint8), num_samples=num_samples, k=k)
-    np.save(dist_path, dist)
-    with open(prm_path, 'wb') as f:
-        pickle.dump(prm, f)
+    try:
+        dist = distance_transform((grid != 0).astype(np.uint8))
+        prm = build_prm((grid != 0).astype(np.uint8), num_samples=num_samples, k=k)
+    except Exception as exc:
+        raise GroundTruthGenerationError(
+            f"preprocess_map: failed to build PRM for {map_id}: {exc}") from exc
+    try:
+        np.save(dist_path, dist)
+        with open(prm_path, "wb") as f:
+            pickle.dump(prm, f)
+    except Exception as exc:
+        raise GroundTruthGenerationError(
+            f"preprocess_map: failed to write cache for {map_id}: {exc}") from exc
     return dist, prm
 
 
 def densify_path(nodes: list[Tuple[int, int]], step: float) -> list[Tuple[int, int]]:
-    result = []
+    """Interpolate path segments so consecutive points are at most ``step`` apart."""
+    if step <= 0:
+        raise GroundTruthGenerationError("densify_path: step must be positive")
+    if len(nodes) < 2:
+        raise GroundTruthGenerationError("densify_path: need at least two nodes")
+    result: list[Tuple[int, int]] = []
     for i in range(len(nodes) - 1):
         x1, y1 = nodes[i]
         x2, y2 = nodes[i + 1]
@@ -82,18 +124,30 @@ def densify_path(nodes: list[Tuple[int, int]], step: float) -> list[Tuple[int, i
 def process_file(file_path: Path, output_dir: Path, samples: int, k: int, dil_rad: int, blur_sigma: float):
     grid, clearance, step = load_npz(file_path)
     map_id = file_path.stem.split('_')[0]
-    start = tuple(np.argwhere(grid == 8)[0][::-1])
-    goal = tuple(np.argwhere(grid == 9)[0][::-1])
+    starts = np.argwhere(grid == 8)
+    goals = np.argwhere(grid == 9)
+    if starts.size == 0 or goals.size == 0:
+        raise GroundTruthGenerationError(
+            f"process_file: start/goal missing in {file_path}")
+    start = tuple(starts[0][::-1])
+    goal = tuple(goals[0][::-1])
+
     dist, base_prm = preprocess_map(map_id, grid, samples, k)
     filtered = filter_graph(base_prm, dist, clearance, step)
     if filtered.number_of_nodes() == 0:
-        return
-    goal_node = snap_point(filtered, goal)
-    planner = DStarLite(filtered, goal_node)
-    start_node = snap_point(filtered, start)
-    node_path = planner.replan(start_node)
+        raise GroundTruthGenerationError(
+            f"process_file: no nodes left after filtering for {file_path}")
+    try:
+        goal_node = snap_point(filtered, goal)
+        planner = DStarLite(filtered, goal_node)
+        start_node = snap_point(filtered, start)
+        node_path = planner.replan(start_node)
+    except Exception as exc:
+        raise GroundTruthGenerationError(
+            f"process_file: planning failed for {file_path}: {exc}") from exc
     if not node_path:
-        return
+        raise GroundTruthGenerationError(
+            f"process_file: planner returned empty path for {file_path}")
     coord_path = [filtered.nodes[n]['pos'] for n in node_path]
     dense_path = densify_path(coord_path, step)
     indices = np.zeros_like(grid, dtype=np.int32)
@@ -107,9 +161,13 @@ def process_file(file_path: Path, output_dir: Path, samples: int, k: int, dil_ra
     if heat.max() > 0:
         heat /= heat.max()
     out_base = output_dir / file_path.stem
-    np.save(out_base.with_suffix('.indices.npy'), indices)
-    np.save(out_base.with_suffix('.mask.npy'), mask)
-    np.save(out_base.with_suffix('.heat.npy'), heat)
+    try:
+        np.save(out_base.with_suffix('.indices.npy'), indices)
+        np.save(out_base.with_suffix('.mask.npy'), mask)
+        np.save(out_base.with_suffix('.heat.npy'), heat)
+    except Exception as exc:
+        raise GroundTruthGenerationError(
+            f"process_file: failed to write outputs for {file_path}: {exc}") from exc
 
 
 def main() -> None:
@@ -117,10 +175,21 @@ def main() -> None:
     out_dir = Path(args.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     files = sorted(Path(args.input_dir).glob('*.npz'))
-    worker = partial(process_file, output_dir=out_dir, samples=args.samples, k=args.k_neighbors, dil_rad=args.dilate_radius, blur_sigma=args.blur_sigma)
+    if not files:
+        raise GroundTruthGenerationError(
+            f"main: no .npz files found in {args.input_dir}")
+    worker = partial(
+        process_file,
+        output_dir=out_dir,
+        samples=args.samples,
+        k=args.k_neighbors,
+        dil_rad=args.dilate_radius,
+        blur_sigma=args.blur_sigma,
+    )
     if args.processes > 1:
         with Pool(args.processes) as pool:
-            list(pool.imap_unordered(worker, files))
+            for _ in pool.imap_unordered(worker, files):
+                pass
     else:
         for f in files:
             worker(f)


### PR DESCRIPTION
## Summary
- raise `GroundTruthGenerationError` when ground truth generation runs into a problem
- validate `.npz` files
- detect missing start/goal points
- check cached data and file writes
- verify dataset directory before processing

## Testing
- `pytest tests/unit/test_ground_truth_heatmap.py::test_prm_and_betweenness -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6862ca032c0083258e78b27ae7209245