### PR TITLE
Add configurable YAML for ground truth generation

### DIFF
--- a/configs/data_generation/ground_truth_generation.yaml
+++ b/configs/data_generation/ground_truth_generation.yaml
@@ -1,0 +1,7 @@
+input_dir: data/training_samples
+output_dir: data/ground_truth
+samples: 500
+k_neighbors: 10
+processes: 1
+dilate_radius: 2
+blur_sigma: 1.0


### PR DESCRIPTION
## Summary
- add YAML config for ground truth generation
- allow `generate_ground_truth.py` to load settings from YAML

## Testing
- `pip install -r environment/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f6c2469c8325908544102f0b22c1