### PR TITLE
Store ground truth outputs in npz format

### DIFF
--- a/scripts/data_generation/generate_ground_truth.py
+++ b/scripts/data_generation/generate_ground_truth.py
@@ -261,9 +261,12 @@ def process_file(
         heat /= heat.max()
     out_base = output_dir / file_path.stem
     try:
-        np.save(out_base.with_suffix(".indices.npy"), indices)
-        np.save(out_base.with_suffix(".mask.npy"), mask)
-        np.save(out_base.with_suffix(".heat.npy"), heat)
+        np.savez_compressed(
+            out_base.with_suffix(".npz"),
+            indices=indices,
+            mask=mask,
+            heatmap=heat,
+        )
     except Exception as exc:
         raise GroundTruthGenerationError(
             f"process_file: failed to write outputs for {file_path}: {exc}"

--- a/scripts/utils/visualize_ground_truth.py
+++ b/scripts/utils/visualize_ground_truth.py
@@ -21,9 +21,10 @@ def compose_visualization(sample_path: Path, gt_dir: Path, show_indices: bool = 
     # Load base sample and ground truth arrays
     sample = np.load(sample_path, allow_pickle=True)
     grid = sample["map"]
-    indices = np.load(base.with_suffix(".indices.npy"))
-    mask = np.load(base.with_suffix(".mask.npy"))
-    heat = np.load(base.with_suffix(".heat.npy"))
+    gt = np.load(base.with_suffix(".npz"))
+    indices = gt["indices"]
+    mask = gt["mask"]
+    heat = gt["heatmap"]
 
     # Determine start and goal coordinates (x, y)
     start_pos = np.argwhere(grid == 8)


### PR DESCRIPTION
## Summary
- store generated ground truth arrays in a single `.npz` file
- update visualization utility to read the new archive format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653bc77d6c8325a0df5a0f5ba4fd60