### PR TITLE
Add utility to fix unreachable start-goal pairs

### DIFF
--- a/scripts/utils/fix_unreachable_maps.py
+++ b/scripts/utils/fix_unreachable_maps.py
@@ -1,0 +1,78 @@
+import argparse
+from pathlib import Path
+import numpy as np
+from collections import deque
+import random
+
+
+def path_exists(grid: np.ndarray) -> bool:
+    start_pos = np.argwhere(grid == 8)
+    goal_pos = np.argwhere(grid == 9)
+    if start_pos.size == 0 or goal_pos.size == 0:
+        return False
+    start = tuple(start_pos[0])
+    goal = tuple(goal_pos[0])
+    q = deque([start])
+    visited = {start}
+    free = lambda y, x: grid[y, x] in (0, 8, 9)
+    while q:
+        y, x = q.popleft()
+        if (y, x) == goal:
+            return True
+        for dy, dx in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
+            ny, nx = y + dy, x + dx
+            if 0 <= ny < grid.shape[0] and 0 <= nx < grid.shape[1]:
+                if free(ny, nx) and (ny, nx) not in visited:
+                    visited.add((ny, nx))
+                    q.append((ny, nx))
+    return False
+
+
+def random_free_cell(grid: np.ndarray) -> tuple[int, int]:
+    free = np.argwhere(grid == 0)
+    if free.size == 0:
+        raise ValueError("No free cells available")
+    idx = random.randrange(len(free))
+    y, x = free[idx]
+    return int(y), int(x)
+
+
+def fix_file(path: Path) -> bool:
+    data = np.load(path, allow_pickle=True)
+    grid = data["map"].copy()
+    start_pos = tuple(np.argwhere(grid == 8)[0])
+    goal_pos = tuple(np.argwhere(grid == 9)[0])
+    if path_exists(grid):
+        return False
+    # remove old markers
+    grid[start_pos] = 0
+    grid[goal_pos] = 0
+    for _ in range(1000):
+        new_start = random_free_cell(grid)
+        new_goal = random_free_cell(grid)
+        if new_start == new_goal:
+            continue
+        grid[new_start] = 8
+        grid[new_goal] = 9
+        if path_exists(grid):
+            data_dict = dict(data)
+            data_dict["map"] = grid
+            np.savez(path, **data_dict)
+            print(f"Edited {path}: start {start_pos}->{new_start}, goal {goal_pos}->{new_goal}")
+            return True
+        grid[new_start] = 0
+        grid[new_goal] = 0
+    print(f"Could not find new positions for {path}")
+    return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fix maps without valid paths")
+    parser.add_argument("directory", type=Path, help="Directory with .npz maps")
+    args = parser.parse_args()
+    for p in sorted(args.directory.glob("*.npz")):
+        fix_file(p)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_fix_unreachable_maps.py
+++ b/tests/unit/test_fix_unreachable_maps.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import numpy as np
+import sys
+
+SRC_PATH = Path(__file__).resolve().parents[2]
+sys.path.append(str(SRC_PATH))
+
+from scripts.utils.fix_unreachable_maps import path_exists, fix_file
+
+
+def test_path_exists_blocked():
+    grid = np.zeros((5, 5), dtype=np.uint8)
+    grid[0, 0] = 8
+    grid[4, 4] = 9
+    assert path_exists(grid)
+    grid[:, 2] = 1
+    assert not path_exists(grid)
+
+
+def test_fix_file(tmp_path):
+    grid = np.zeros((5, 5), dtype=np.uint8)
+    grid[0, 0] = 8
+    grid[4, 4] = 9
+    grid[:, 2] = 1
+    path = tmp_path / "sample.npz"
+    np.savez(path, map=grid, clearance=0.1, step_size=1.0, config="{}")
+    assert not path_exists(grid)
+    assert fix_file(path)
+    data = np.load(path)
+    new_grid = data["map"]
+    assert path_exists(new_grid)
+    start = tuple(np.argwhere(new_grid == 8)[0])
+    goal = tuple(np.argwhere(new_grid == 9)[0])
+    assert start != goal


### PR DESCRIPTION
## Summary
- add `fix_unreachable_maps.py` to randomize start/goal when no path exists
- add tests for the new utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68663908018483259308fcecb5fb4f4e