### PR TITLE
Fix densify_path when start and goal snap to same node

### DIFF
--- a/scripts/data_generation/generate_ground_truth.py
+++ b/scripts/data_generation/generate_ground_truth.py
@@ -221,13 +221,13 @@ def process_file(
             f"process_file: no nodes left after filtering for {file_path}"
         )
     node_path = _plan(filtered, start, goal)
-    if not node_path:
+    if len(node_path) < 2:
         try:
             start, goal = reposition_start_goal(grid, filtered)
         except GroundTruthGenerationError:
             raise
         node_path = _plan(filtered, start, goal)
-        if not node_path:
+        if len(node_path) < 2:
             raise GroundTruthGenerationError(
                 f"process_file: planner returned empty path for {file_path}"
             )


### PR DESCRIPTION
## Summary
- avoid densify_path failure by checking path length

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68663e62d0208325bc4f4449403c8cfa