### PR TITLE
Fix cache loading error for ground truth generation

### DIFF
--- a/scripts/data_generation/generate_ground_truth.py
+++ b/scripts/data_generation/generate_ground_truth.py
@@ -98,11 +98,12 @@ def preprocess_map(map_id: str, grid: np.ndarray, num_samples: int, k: int):
             dist = np.load(dist_path)
             with open(prm_path, "rb") as f:
                 prm = pickle.load(f)
-        except Exception as exc:
-            raise GroundTruthGenerationError(
-                f"preprocess_map: failed to load cache for {map_id}: {exc}"
-            ) from exc
-        return dist, prm
+            return dist, prm
+        except Exception:
+            # Corrupted cache files can occur if a previous run was interrupted
+            # while writing. Remove them and regenerate from scratch.
+            dist_path.unlink(missing_ok=True)
+            prm_path.unlink(missing_ok=True)
     try:
         dist = distance_transform((grid != 0).astype(np.uint8))
         prm = build_prm((grid != 0).astype(np.uint8), num_samples=num_samples, k=k)


### PR DESCRIPTION
## Summary
- fix `preprocess_map` to discard corrupted cache files instead of failing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68668ba10ed48325a9703561998ec607