### PR TITLE
Handle start and goal cells in PRM

### DIFF
--- a/src/data_generation/ground_truth_heatmaps.py
+++ b/src/data_generation/ground_truth_heatmaps.py
@@ -27,7 +27,7 @@ class HeatmapConfig:
 
 
 def _sample_free_points(grid: np.ndarray, num_samples: int) -> List[Tuple[int, int]]:
-    free = np.argwhere(grid == 0)
+    free = np.argwhere(np.isin(grid, (0, 8, 9)))
     if len(free) == 0:
         return []
     idx = np.random.choice(len(free), size=min(num_samples, len(free)), replace=False)
@@ -57,7 +57,7 @@ def _bresenham_line(x0: int, y0: int, x1: int, y1: int) -> Iterable[Tuple[int, i
 
 def _collision_free(grid: np.ndarray, p: Tuple[int, int], q: Tuple[int, int]) -> bool:
     for x, y in _bresenham_line(p[0], p[1], q[0], q[1]):
-        if grid[y, x] != 0:
+        if grid[y, x] not in (0, 8, 9):
             return False
     return True
 

--- a/src/planning_algorithms/prm.py
+++ b/src/planning_algorithms/prm.py
@@ -6,7 +6,7 @@ from scipy.spatial import cKDTree
 
 
 def sample_free_points(grid: np.ndarray, num_samples: int) -> List[Tuple[int, int]]:
-    free = np.argwhere(grid == 0)
+    free = np.argwhere(np.isin(grid, (0, 8, 9)))
     if len(free) == 0:
         return []
     if len(free) <= num_samples:
@@ -38,7 +38,7 @@ def bresenham_line(x0: int, y0: int, x1: int, y1: int):
 
 def is_collision_free(grid: np.ndarray, p: Tuple[int, int], q: Tuple[int, int]) -> bool:
     for x, y in bresenham_line(p[0], p[1], q[0], q[1]):
-        if grid[y, x] != 0:
+        if grid[y, x] not in (0, 8, 9):
             return False
     return True
 

--- a/tests/unit/test_prm_collision_free.py
+++ b/tests/unit/test_prm_collision_free.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import sys
+
+import numpy as np
+
+SRC_PATH = Path(__file__).resolve().parents[2] / 'src'
+sys.path.append(str(SRC_PATH))
+
+from planning_algorithms.prm import is_collision_free, sample_free_points
+
+
+def test_start_goal_cells_allowed():
+    grid = np.zeros((5, 5), dtype=np.uint8)
+    grid[2, 2] = 8
+    assert is_collision_free(grid, (0, 0), (4, 4))
+    pts = sample_free_points(grid, 30)
+    assert (2, 2) in pts
+    grid[2, 2] = 9
+    assert is_collision_free(grid, (0, 0), (4, 4))
+    pts = sample_free_points(grid, 30)
+    assert (2, 2) in pts


### PR DESCRIPTION
## Summary
- treat cells labeled 8 or 9 as free space in PRM utilities
- sample start/goal cells when building PRMs
- allow PRM edges through start/goal cells
- add regression test for collision checking around start/goal cells

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d63e489c83258079326f2b41c48a