### PR TITLE
Add collision debug info

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,8 @@ A script is provided to automatically generate synthetic occupancy grids for tra
 python scripts/data_generation/generate_pybullet_envs.py --output-dir data/raw --num-scenes 50 --archetype clutter --resolution 128
 ```
 
+When generating ground truth paths with `generate_ground_truth.py`, any
+collision between the planned path and map obstacles triggers a warning that
+includes the coordinates of the first colliding segment. This additional output
+helps diagnose problematic maps during dataset creation.
+

--- a/scripts/data_generation/generate_ground_truth.py
+++ b/scripts/data_generation/generate_ground_truth.py
@@ -23,7 +23,13 @@ import yaml
 class GroundTruthGenerationError(RuntimeError):
     """Raised when ground truth generation fails."""
 
-    pass
+    def __init__(
+        self,
+        message: str,
+        segment: tuple[tuple[int, int], tuple[int, int]] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.segment = segment
 
 
 SRC_PATH = Path(__file__).resolve().parents[2] / "src"
@@ -143,16 +149,23 @@ def densify_path(nodes: list[Tuple[int, int]], step: float) -> list[Tuple[int, i
     return result
 
 
-def path_collision_free(grid: np.ndarray, path: list[Tuple[int, int]]) -> bool:
-    """Check that ``path`` does not intersect occupied cells in ``grid``."""
+def path_collision_free(
+    grid: np.ndarray, path: list[Tuple[int, int]]
+) -> tuple[bool, tuple[tuple[int, int], tuple[int, int]] | None]:
+    """Check that ``path`` does not intersect occupied cells in ``grid``.
+
+    Returns a tuple ``(collision_free, segment)`` where ``segment`` is the first
+    path segment that collides with an obstacle, or ``None`` if the path is
+    collision-free.
+    """
     occ = (grid != 0).astype(np.uint8)
     occ[grid == 8] = 0
     occ[grid == 9] = 0
     for (x1, y1), (x2, y2) in zip(path[:-1], path[1:]):
         for x, y in bresenham_line(x1, y1, x2, y2):
             if occ[int(y), int(x)]:
-                return False
-    return True
+                return False, ((int(x1), int(y1)), (int(x2), int(y2)))
+    return True, None
 
 
 def _plan(graph: nx.Graph, start: Tuple[int, int], goal: Tuple[int, int]) -> list[int]:
@@ -242,9 +255,11 @@ def process_file(
             )
     coord_path = [filtered.nodes[n]["pos"] for n in node_path]
     dense_path = densify_path(coord_path, step)
-    if not path_collision_free(grid, dense_path):
+    collision_free, segment = path_collision_free(grid, dense_path)
+    if not collision_free:
         raise GroundTruthGenerationError(
-            f"process_file: generated path intersects obstacles for {file_path}"
+            f"process_file: generated path intersects obstacles for {file_path} at segment {segment}",
+            segment=segment,
         )
     indices = np.zeros_like(grid, dtype=np.int32)
     mask = np.zeros_like(grid, dtype=np.uint8)
@@ -289,7 +304,10 @@ def safe_process_file(
             blur_sigma=blur_sigma,
         )
     except GroundTruthGenerationError as exc:
-        warnings.warn(str(exc), RuntimeWarning)
+        msg = str(exc)
+        if exc.segment is not None:
+            msg += f" (segment {exc.segment})"
+        warnings.warn(msg, RuntimeWarning)
     except Exception as exc:  # noqa: BLE001
         warnings.warn(f"Unexpected error processing {file_path}: {exc}", RuntimeWarning)
 


### PR DESCRIPTION
## Summary
- extend `GroundTruthGenerationError` to store colliding segment
- update `path_collision_free` to return the first colliding segment
- show segment info in `process_file` and `safe_process_file`
- document the new warning output in the README

## Testing
- `pip install -r environment/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d82965c48325a324311d2b4f6603