### PR TITLE
Include start/end points in paths and overlay cached PRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,6 @@ collision between the planned path and map obstacles triggers a warning that
 includes the coordinates of the first colliding segment. This additional output
 helps diagnose problematic maps during dataset creation.
 
+
+The script caches probabilistic roadmaps in `.cache/`. Use `--clear-cache` to remove existing cache files before generating new data.
+Ground truth visualization parameters are read from `configs/data_generation/visualize_ground_truth.yaml`, which also controls whether the cached PRM overlay is shown.

--- a/configs/data_generation/visualize_ground_truth.yaml
+++ b/configs/data_generation/visualize_ground_truth.yaml
@@ -1,0 +1,11 @@
+# Configuration for ground truth visualization
+# Path to directory containing generated ground truth .npz files
+ground_truth_dir: data/ground_truth
+# Directory where cached PRMs are stored
+cache_dir: .cache
+# PRM parameters used during ground truth generation
+samples: 500
+k_neighbors: 10
+# Toggle optional overlays
+show_indices: false
+show_prm: true


### PR DESCRIPTION
## Summary
- ensure generated path starts and ends at the start/goal cells
- extend visualization tool to load and display cached PRM roadmaps
- use YAML config for visualizer and save filtered PRM for each environment
- document cache handling and visualization config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab85b405c8325bcad9864383dbff7