### PR TITLE
Include config for PRM caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,11 @@ collision between the planned path and map obstacles triggers a warning that
 includes the coordinates of the first colliding segment. This additional output
 helps diagnose problematic maps during dataset creation.
 
+
+The generator stores PRM data in directories defined in
+`configs/data_generation/ground_truth_generation.yaml`. Set
+`clear_cache: true` in that file to remove existing cache files before
+running. Set `save_filtered_prm: false` to skip writing the filtered
+roadmap cache. Ground truth visualization parameters are read from
+`configs/data_generation/visualize_ground_truth.yaml`, which also
+controls whether the cached PRM overlay is shown.

--- a/configs/data_generation/ground_truth_generation.yaml
+++ b/configs/data_generation/ground_truth_generation.yaml
@@ -5,3 +5,11 @@ k_neighbors: 10
 processes: 1
 dilate_radius: 2
 blur_sigma: 1.0
+# Directory for distance transform and base PRM cache
+cache_dir: .cache/base
+# Directory for filtered PRM cache
+filtered_cache_dir: .cache/filtered
+# Whether to store the filtered PRM for each environment
+save_filtered_prm: true
+# Remove cached files before running
+clear_cache: false

--- a/configs/data_generation/visualize_ground_truth.yaml
+++ b/configs/data_generation/visualize_ground_truth.yaml
@@ -1,0 +1,11 @@
+# Configuration for ground truth visualization
+# Path to directory containing generated ground truth .npz files
+ground_truth_dir: data/ground_truth
+# Directory where filtered PRMs are stored
+filtered_cache_dir: .cache/filtered
+# PRM parameters used during ground truth generation
+samples: 500
+k_neighbors: 10
+# Toggle optional overlays
+show_indices: false
+show_prm: true

--- a/scripts/data_generation/generate_ground_truth.py
+++ b/scripts/data_generation/generate_ground_truth.py
@@ -44,10 +44,6 @@ from utils.image_processing import distance_transform, dilate, gaussian_blur
 from utils.graph_helpers import filter_graph, snap_point, bresenham_line
 
 
-CACHE_DIR = Path(".cache")
-CACHE_DIR.mkdir(exist_ok=True)
-
-
 def grid_hash(grid: np.ndarray) -> str:
     """Return a short hash string for ``grid``."""
     h = hashlib.sha256()
@@ -55,10 +51,12 @@ def grid_hash(grid: np.ndarray) -> str:
     return h.hexdigest()[:16]
 
 
-def clear_cache() -> None:
-    """Remove all cached files."""
-    shutil.rmtree(CACHE_DIR, ignore_errors=True)
-    CACHE_DIR.mkdir(exist_ok=True)
+def clear_cache(cache_dir: Path, filtered_cache_dir: Path) -> None:
+    """Remove all cached files in ``cache_dir`` and ``filtered_cache_dir``."""
+    shutil.rmtree(cache_dir, ignore_errors=True)
+    shutil.rmtree(filtered_cache_dir, ignore_errors=True)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    filtered_cache_dir.mkdir(parents=True, exist_ok=True)
 
 
 def load_config(path: Path) -> dict:
@@ -78,12 +76,6 @@ def parse_args() -> argparse.Namespace:
         default=str(default_cfg),
         help='YAML configuration file',
     )
-    p.add_argument(
-        '--clear-cache',
-        action='store_true',
-        help='remove cached preprocessing results before running',
-    )
-
     return p.parse_args()
 
 
@@ -112,7 +104,13 @@ def load_npz(file_path: Path):
     return grid, c, s, cfg
 
 
-def preprocess_map(map_id: str, grid: np.ndarray, num_samples: int, k: int):
+def preprocess_map(
+    map_id: str,
+    grid: np.ndarray,
+    num_samples: int,
+    k: int,
+    cache_dir: Path,
+):
     """Compute and cache distance transform and PRM for a map.
 
     The cache key is derived from a hash of ``grid`` so identical maps share
@@ -123,8 +121,8 @@ def preprocess_map(map_id: str, grid: np.ndarray, num_samples: int, k: int):
             f"preprocess_map: empty grid for map_id={map_id}"
         )
     key = f"{grid_hash(grid)}_{num_samples}_{k}"
-    dist_path = CACHE_DIR / f"{key}_dist.npy"
-    prm_path = CACHE_DIR / f"{key}_prm.pkl"
+    dist_path = cache_dir / f"{key}_dist.npy"
+    prm_path = cache_dir / f"{key}_prm.pkl"
     if dist_path.exists() and prm_path.exists():
         try:
             dist = np.load(dist_path)
@@ -268,6 +266,9 @@ def process_file(
     k: int,
     dil_rad: int,
     blur_sigma: float,
+    cache_dir: Path,
+    filtered_cache_dir: Path,
+    save_filtered_prm: bool,
 ):
     grid, clearance, step, cfg = load_npz(file_path)
     map_id = file_path.stem.split("_")[0]
@@ -280,8 +281,18 @@ def process_file(
     start = tuple(starts[0][::-1])
     goal = tuple(goals[0][::-1])
 
-    dist, base_prm = preprocess_map(map_id, grid, samples, k)
+    dist, base_prm = preprocess_map(map_id, grid, samples, k, cache_dir)
     filtered = filter_graph(base_prm, dist, clearance, step)
+    cache_key = f"{grid_hash(grid)}_{samples}_{k}_{clearance}_{step}"
+    filtered_path = filtered_cache_dir / f"{cache_key}_filtered_prm.pkl"
+    if save_filtered_prm and not filtered_path.exists():
+        try:
+            with open(filtered_path, "wb") as f:
+                pickle.dump(filtered, f)
+        except Exception as exc:  # noqa: BLE001
+            warnings.warn(
+                f"Failed to cache filtered PRM for {file_path}: {exc}", RuntimeWarning
+            )
     if filtered.number_of_nodes() == 0:
         raise GroundTruthGenerationError(
             f"process_file: no nodes left after filtering for {file_path}"
@@ -310,7 +321,11 @@ def process_file(
             warnings.warn(
                 f"Failed to update input map {file_path}: {exc}", RuntimeWarning
             )
-    coord_path = [filtered.nodes[n]["pos"] for n in node_path]
+    # Include the actual start and goal positions in the coordinate path so the
+    # resulting dense path begins and ends exactly at these cells.
+    coord_path = [start]
+    coord_path.extend(filtered.nodes[n]["pos"] for n in node_path)
+    coord_path.append(goal)
     dense_path = densify_path(coord_path, step)
     if not path_collision_free(grid, dense_path):
         fallback = grid_shortest_path(grid, start, goal)
@@ -350,6 +365,9 @@ def safe_process_file(
     k: int,
     dil_rad: int,
     blur_sigma: float,
+    cache_dir: Path,
+    filtered_cache_dir: Path,
+    save_filtered_prm: bool,
 ) -> None:
     """Run ``process_file`` and issue a warning if it fails."""
     try:
@@ -360,6 +378,9 @@ def safe_process_file(
             k=k,
             dil_rad=dil_rad,
             blur_sigma=blur_sigma,
+            cache_dir=cache_dir,
+            filtered_cache_dir=filtered_cache_dir,
+            save_filtered_prm=save_filtered_prm,
         )
     except GroundTruthGenerationError as exc:
         msg = str(exc)
@@ -372,9 +393,15 @@ def safe_process_file(
 
 def main() -> None:
     args = parse_args()
-    if args.clear_cache:
-        clear_cache()
     cfg = load_config(Path(args.config))
+
+    cache_dir = Path(cfg.get('cache_dir', '.cache'))
+    filtered_cache_dir = Path(cfg.get('filtered_cache_dir', cache_dir))
+    save_filtered_prm = bool(cfg.get('save_filtered_prm', True))
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    filtered_cache_dir.mkdir(parents=True, exist_ok=True)
+    if cfg.get('clear_cache', False):
+        clear_cache(cache_dir, filtered_cache_dir)
 
     try:
         input_dir = Path(cfg['input_dir'])
@@ -399,6 +426,9 @@ def main() -> None:
         k=k_neigh,
         dil_rad=dil_rad,
         blur_sigma=blur_sigma,
+        cache_dir=cache_dir,
+        filtered_cache_dir=filtered_cache_dir,
+        save_filtered_prm=save_filtered_prm,
     )
     if processes > 1:
         with Pool(processes) as pool:

--- a/scripts/utils/visualize_ground_truth.py
+++ b/scripts/utils/visualize_ground_truth.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
+import pickle
 from pathlib import Path
+import yaml
+
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -14,8 +18,28 @@ from tkinter import filedialog
 SWITCH_KEY = 'n'
 
 
-def compose_visualization(sample_path: Path, gt_dir: Path, show_indices: bool = False) -> plt.Figure:
-    """Return a matplotlib figure visualizing a ground truth sample."""
+def grid_hash(grid: np.ndarray) -> str:
+    """Return a short hash string for ``grid``."""
+    h = hashlib.sha256()
+    h.update(grid.tobytes())
+    return h.hexdigest()[:16]
+
+
+def compose_visualization(
+    sample_path: Path,
+    gt_dir: Path,
+    *,
+    show_indices: bool,
+    show_prm: bool,
+    prm_samples: int,
+    prm_k: int,
+    filtered_cache_dir: Path,
+) -> plt.Figure:
+    """Return a matplotlib figure visualizing a ground truth sample.
+
+    The PRM overlay is loaded from ``filtered_cache_dir`` using the same cache key
+    employed during ground truth generation.
+    """
     base = gt_dir / sample_path.with_suffix("").name
 
     # Load base sample and ground truth arrays
@@ -48,17 +72,37 @@ def compose_visualization(sample_path: Path, gt_dir: Path, show_indices: bool = 
     goal_plot = ax.scatter(goal[0], goal[1], s=150, c="red", marker="*",
                            edgecolors="black", linewidths=1, label="Goal", zorder=3)
 
-    # --- Layer 3: probabilistic heatmap ---
+    # --- Optional Layer 3: PRM roadmap ---
+    if show_prm:
+        clearance = float(sample["clearance"])
+        step = float(sample["step_size"])
+        key = f"{grid_hash(grid)}_{prm_samples}_{prm_k}_{clearance}_{step}"
+        prm_path = filtered_cache_dir / f"{key}_filtered_prm.pkl"
+        if prm_path.exists():
+            with open(prm_path, "rb") as f:
+                prm = pickle.load(f)
+            for u, v in prm.edges():
+                x1, y1 = prm.nodes[u]["pos"]
+                x2, y2 = prm.nodes[v]["pos"]
+                ax.plot([x1, x2], [y1, y2], color="black", linewidth=0.5, alpha=0.5, zorder=2)
+            if prm.number_of_nodes() > 0:
+                pts = np.array([prm.nodes[n]["pos"] for n in prm.nodes])
+                ax.scatter(pts[:, 0], pts[:, 1], s=8, c="black", alpha=0.7, zorder=2)
+        else:
+            ax.text(0.5, 0.5, "PRM cache missing", transform=ax.transAxes, ha="center", va="center",
+                    color="red", fontsize=10, zorder=5)
+
+    # --- Layer 4: probabilistic heatmap ---
     ax.imshow(heat, cmap="viridis", alpha=0.6, origin="lower")
 
-    # --- Layer 4: raw planner path ---
+    # --- Layer 5: raw planner path ---
     path_coords = np.argwhere(indices > 0)
     order = np.argsort(indices[path_coords[:, 0], path_coords[:, 1]])
     path = path_coords[order]
     (path_plot,) = ax.plot(path[:, 1], path[:, 0], color="cyan", linewidth=1,
                            label="Raw Path", zorder=4)
 
-    # --- Optional Layer 5: step indices ---
+    # --- Optional Layer 6: step indices ---
     if show_indices:
         for y, x in path:
             idx = int(indices[y, x])
@@ -74,19 +118,42 @@ def compose_visualization(sample_path: Path, gt_dir: Path, show_indices: bool = 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Visualize ground truth samples")
-    parser.add_argument("--ground_truth_dir", type=Path, required=True,
-                        help="Directory containing ground truth .npy files")
-    parser.add_argument("--show-indices", action="store_true",
-                        help="Overlay step numbers on the path")
+    default_cfg = (
+        Path(__file__).resolve().parents[2]
+        / "configs/data_generation/visualize_ground_truth.yaml"
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=default_cfg,
+        help="YAML configuration file",
+    )
     args = parser.parse_args()
+    cfg = yaml.safe_load(args.config.read_text())
+    gt_dir = Path(cfg.get("ground_truth_dir", "data/ground_truth"))
+    show_indices = bool(cfg.get("show_indices", False))
+    show_prm = bool(cfg.get("show_prm", True))
+    prm_samples = int(cfg.get("samples", 500))
+    prm_k = int(cfg.get("k_neighbors", 10))
+    filtered_cache_dir = Path(cfg.get("filtered_cache_dir", ".cache/filtered"))
 
     root = tk.Tk()
     root.withdraw()
     while True:
-        sample_path = filedialog.askopenfilename(title="Select .npz sample file", filetypes=[("NPZ files", "*.npz")])
+        sample_path = filedialog.askopenfilename(
+            title="Select .npz sample file", filetypes=[("NPZ files", "*.npz")]
+        )
         if not sample_path:
             break
-        fig = compose_visualization(Path(sample_path), args.ground_truth_dir, args.show_indices)
+        fig = compose_visualization(
+            Path(sample_path),
+            gt_dir,
+            show_indices=show_indices,
+            show_prm=show_prm,
+            prm_samples=prm_samples,
+            prm_k=prm_k,
+            filtered_cache_dir=filtered_cache_dir,
+        )
         switch_file = {'next': False}
 
         def on_key(event):


### PR DESCRIPTION
## Summary
- rely solely on YAML for ground truth generation parameters
- configure cache directories via `ground_truth_generation.yaml`
- cache filtered PRMs in a dedicated directory and load them in the visualizer
- toggle saving of filtered PRMs via `save_filtered_prm`
- update README with new instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ab85b405c8325bcad9864383dbff7