### PR TITLE
Enable multiprocessing from config

### DIFF
--- a/configs/data_generation/sample_training_data.yaml
+++ b/configs/data_generation/sample_training_data.yaml
@@ -2,6 +2,7 @@ seed: 42
 output_dir: data/test_samples
 num_maps: 10
 samples_per_map: 2
+processes: 1
 map_resolution: 200
 shell_thickness: 2
 bsp:

--- a/scripts/data_generation/generate_training_data.py
+++ b/scripts/data_generation/generate_training_data.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+from multiprocessing import Pool
+from functools import partial
 from pathlib import Path
 from typing import Dict, List
 import random
@@ -32,6 +34,18 @@ def load_config(path: Path) -> Dict:
         return yaml.safe_load(f)
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Generate training data')
+    default_cfg = (
+        Path(__file__).resolve().parents[2]
+        / 'configs/data_generation/sample_training_data.yaml'
+    )
+    parser.add_argument(
+        '--config', type=str, default=str(default_cfg), help='YAML configuration file'
+    )
+    return parser.parse_args()
+
+
 def choose_free_cell(grid: np.ndarray, rng: random.Random, clearance: float = 0.0) -> tuple[int, int]:
     free_mask = grid == 0
     if clearance > 0:
@@ -46,11 +60,45 @@ def choose_free_cell(grid: np.ndarray, rng: random.Random, clearance: float = 0.
     return int(y), int(x)
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description='Generate training data')
-    parser.add_argument('--config', type=str, required=True)
-    args = parser.parse_args()
+def process_map(
+    map_idx: int,
+    cfg: Dict,
+    samples_per_map: int,
+    robots: List[Dict],
+    base_seed: int,
+    out_dir: Path,
+) -> None:
+    rng_seed = base_seed + map_idx
+    rng = random.Random(rng_seed)
+    np.random.seed(rng_seed)
 
+    logging.info("Generating map %d/%d", map_idx + 1, cfg.get("num_maps", 1))
+    base = generate_office_map(cfg, rng)
+    if not flood_fill_connected(base):
+        logging.warning("Map %d is not fully connected", map_idx)
+    for sample_idx in range(samples_per_map):
+        for robot_idx, robot in enumerate(robots):
+            sample = base.copy()
+            clearance = float(robot.get("clearance", 0.0))
+            sy, sx = choose_free_cell(sample, rng, clearance)
+            gy, gx = choose_free_cell(sample, rng, clearance)
+            while (gy, gx) == (sy, sx):
+                gy, gx = choose_free_cell(sample, rng, clearance)
+            sample[sy, sx] = 8  # start
+            sample[gy, gx] = 9  # goal
+            name = f"map{map_idx:04d}_s{sample_idx:02d}_r{robot_idx:02d}.npz"
+            out_path = out_dir / name
+            np.savez_compressed(
+                out_path,
+                map=sample,
+                clearance=float(robot.get("clearance", 0.2)),
+                step_size=float(robot.get("step_size", 1.0)),
+                config=json.dumps(cfg),
+            )
+
+
+def main() -> None:
+    args = parse_args()
     cfg = load_config(Path(args.config))
     seed = int(cfg.get('seed', 0))
     rng = random.Random(seed)
@@ -62,31 +110,23 @@ def main() -> None:
     num_maps = int(cfg.get('num_maps', 1))
     samples_per_map = int(cfg.get('samples_per_map', 1))
     robots: List[Dict] = cfg.get('robots', [{'clearance': 0.2, 'step_size': 1.0}])
+    processes = int(cfg.get('processes', 1))
 
-    for map_idx in range(num_maps):
-        logging.info('Generating map %d/%d', map_idx + 1, num_maps)
-        base = generate_office_map(cfg, rng)
-        if not flood_fill_connected(base):
-            logging.warning('Map %d is not fully connected', map_idx)
-        for sample_idx in range(samples_per_map):
-            for robot_idx, robot in enumerate(robots):
-                sample = base.copy()
-                clearance = float(robot.get('clearance', 0.0))
-                sy, sx = choose_free_cell(sample, rng, clearance)
-                gy, gx = choose_free_cell(sample, rng, clearance)
-                while (gy, gx) == (sy, sx):
-                    gy, gx = choose_free_cell(sample, rng, clearance)
-                sample[sy, sx] = 8  # Use 8 for start
-                sample[gy, gx] = 9  # Use 9 for goal
-                name = f'map{map_idx:04d}_s{sample_idx:02d}_r{robot_idx:02d}.npz'
-                out_path = out_dir / name
-                np.savez_compressed(
-                    out_path,
-                    map=sample,
-                    clearance=float(robot.get('clearance', 0.2)),
-                    step_size=float(robot.get('step_size', 1.0)),
-                    config=json.dumps(cfg),
-                )
+    worker = partial(
+        process_map,
+        cfg=cfg,
+        samples_per_map=samples_per_map,
+        robots=robots,
+        base_seed=seed,
+        out_dir=out_dir,
+    )
+
+    if processes > 1:
+        with Pool(processes) as pool:
+            pool.map(worker, range(num_maps))
+    else:
+        for map_idx in range(num_maps):
+            worker(map_idx)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- load default config in training data generation
- read `processes` from config instead of CLI
- include `processes` in sample config

## Testing
- `pip install -q -r environment/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b9029ec0083258b840471e1fb4264