### PR TITLE
Implement FiLM layer

### DIFF
--- a/tests/unit/dnn_guidance/test_modules.py
+++ b/tests/unit/dnn_guidance/test_modules.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import sys
+
+import torch
+
+SRC_PATH = Path(__file__).resolve().parents[3] / 'src'
+sys.path.append(str(SRC_PATH))
+
+from dnn_guidance.modules import FiLMLayer
+
+
+def test_film_layer_shape_and_op():
+    B, C, H, W = 2, 256, 8, 8
+    layer = FiLMLayer(robot_param_dim=2, feature_map_channels=C)
+    feature_map = torch.randn(B, C, H, W)
+    robot_vec = torch.randn(B, 2)
+    out = layer(feature_map, robot_vec)
+    assert out.shape == feature_map.shape
+    assert not torch.allclose(out, feature_map)


### PR DESCRIPTION
## Summary
- implement `FiLMLayer` module for Feature-wise Linear Modulation
- add `__init__` so dnn_guidance can be imported
- test FiLMLayer module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687756cda7e48325b22f593ca8eb2243