### PR TITLE
Add configurable ML model parameters

### DIFF
--- a/configs/dnn/unet_film.yaml
+++ b/configs/dnn/unet_film.yaml
@@ -1,0 +1,6 @@
+in_channels: 4
+enc_channels: [32, 64, 128]
+bottleneck_channels: 256
+robot_param_dim: 2
+dec_channels: [128, 64, 32]
+out_channels: 1

--- a/src/dnn_guidance/config.py
+++ b/src/dnn_guidance/config.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Tuple
+
+import yaml
+
+
+@dataclass
+class UNetConfig:
+    """Configuration for :class:`UNetFiLM`."""
+
+    in_channels: int = 4
+    enc_channels: Tuple[int, int, int] = (32, 64, 128)
+    bottleneck_channels: int = 256
+    robot_param_dim: int = 2
+    dec_channels: Tuple[int, int, int] = (128, 64, 32)
+    out_channels: int = 1
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> "UNetConfig":
+        data = yaml.safe_load(Path(path).read_text())
+        return cls(
+            in_channels=int(data.get("in_channels", cls.in_channels)),
+            enc_channels=tuple(data.get("enc_channels", cls.enc_channels)),
+            bottleneck_channels=int(
+                data.get("bottleneck_channels", cls.bottleneck_channels)
+            ),
+            robot_param_dim=int(data.get("robot_param_dim", cls.robot_param_dim)),
+            dec_channels=tuple(data.get("dec_channels", cls.dec_channels)),
+            out_channels=int(data.get("out_channels", cls.out_channels)),
+        )

--- a/tests/unit/dnn_guidance/test_model.py
+++ b/tests/unit/dnn_guidance/test_model.py
@@ -7,6 +7,7 @@ SRC_PATH = Path(__file__).resolve().parents[3] / 'src'
 sys.path.append(str(SRC_PATH))
 
 from dnn_guidance.model import UNetFiLM
+from dnn_guidance.config import UNetConfig
 
 
 def test_unet_film_forward_pass():
@@ -17,3 +18,23 @@ def test_unet_film_forward_pass():
     robot_tensor = torch.randn(B, 2)
     logits = model(grid_tensor, robot_tensor)
     assert logits.shape == (B, 1, 200, 200)
+
+
+def test_unet_config_loading(tmp_path):
+    cfg_text = (
+        "in_channels: 4\n"
+        "enc_channels: [16, 32, 64]\n"
+        "bottleneck_channels: 128\n"
+        "robot_param_dim: 2\n"
+        "dec_channels: [64, 32, 16]\n"
+        "out_channels: 1\n"
+    )
+    cfg_path = tmp_path / "model.yaml"
+    cfg_path.write_text(cfg_text)
+    cfg = UNetConfig.from_yaml(cfg_path)
+    model = UNetFiLM(cfg)
+    grid = torch.randn(1, cfg.in_channels, 200, 200)
+    robot = torch.randn(1, cfg.robot_param_dim)
+    out = model(grid, robot)
+    assert out.shape == (1, cfg.out_channels, 200, 200)
+


### PR DESCRIPTION
## Summary
- make UNetFiLM configurable
- add UNetConfig dataclass with YAML loader
- store default ML model params in `configs/dnn/unet_film.yaml`
- test config loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ab43f0e08325902754265167b188