### PR TITLE
Remove Sigmoid from ResNetFPNFiLM

### DIFF
--- a/src/dnn_guidance/model.py
+++ b/src/dnn_guidance/model.py
@@ -249,7 +249,6 @@ class ResNetFPNFiLM(nn.Module):
             nn.PixelShuffle(2),
             nn.Conv2d(16, 16, kernel_size=3, padding=1, groups=16),
             nn.Conv2d(16, c.out_channels, kernel_size=1),
-            nn.Sigmoid(),
         )
 
     def forward(self, grid_tensor, robot_tensor):

--- a/tests/unit/dnn_guidance/test_model.py
+++ b/tests/unit/dnn_guidance/test_model.py
@@ -86,6 +86,7 @@ def test_resnet_fpn_film_forward_and_config(tmp_path):
     grid = torch.randn(B, cfg.in_channels, 200, 200)
     robot = torch.randn(B, cfg.robot_param_dim)
     out = model(grid, robot)
+    assert not any(isinstance(m, torch.nn.Sigmoid) for m in model.head.modules())
     assert out.shape == (B, cfg.out_channels, 200, 200)
 
 


### PR DESCRIPTION
## Summary
- drop activation from `ResNetFPNFiLM.head`
- assert absence of `nn.Sigmoid` in unit test

## Testing
- `pytest -q`
- `python scripts/model_training/train.py /tmp/train_cfg.yaml --model unet_film --model-config configs/dnn/unet_film.yaml`

------
https://chatgpt.com/codex/tasks/task_e_687e6230a0088325a05b28ede64b9409