### PR TITLE
Add universal inference module

### DIFF
--- a/src/dnn_guidance/inference.py
+++ b/src/dnn_guidance/inference.py
@@ -1,0 +1,61 @@
+"""High-level model inference interface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+import torch
+
+from .data_loader import RobotParamScaling
+
+
+class InferenceHandler:
+    """Run inference with a trained model using simple NumPy inputs.
+
+    Parameters
+    ----------
+    model_class : type
+        Class object of the neural network architecture to instantiate.
+    model_checkpoint_path : str or Path or None
+        Path to a ``state_dict`` checkpoint for the model. If ``None`` the model
+        is used with randomly initialised weights.
+    device : str or torch.device
+        Device on which to run inference.
+    """
+
+    def __init__(self, model_class: type, model_checkpoint_path: str | Path | None, device: str | torch.device = "cpu") -> None:
+        self.device = torch.device(device)
+        self.model = model_class()
+        if model_checkpoint_path is not None:
+            state_dict = torch.load(model_checkpoint_path, map_location=self.device)
+            self.model.load_state_dict(state_dict)
+        self.model.to(self.device)
+        self.model.eval()
+        self.scaling = RobotParamScaling()
+
+    def _preprocess(self, grid_numpy: np.ndarray, robot_numpy: np.ndarray) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Convert raw NumPy arrays to batched tensors on the target device."""
+        grid = np.asarray(grid_numpy)
+        robot = np.asarray(robot_numpy)
+
+        start = (grid == 8).astype(np.float32)
+        goal = (grid == 9).astype(np.float32)
+        traversable = ((grid == 0) | (grid == 8) | (grid == 9)).astype(np.float32)
+        obstacles = 1.0 - traversable
+        grid_tensor = torch.from_numpy(np.stack([start, goal, traversable, obstacles])).unsqueeze(0)
+
+        cl_scaled, step_scaled = self.scaling.scale(float(robot[0]), float(robot[1]))
+        robot_tensor = torch.tensor([[cl_scaled, step_scaled]], dtype=torch.float32)
+
+        return grid_tensor.to(self.device), robot_tensor.to(self.device)
+
+    def predict(self, grid_numpy: np.ndarray, robot_numpy: np.ndarray) -> np.ndarray:
+        """Run the model's forward pass and return a heatmap as a NumPy array."""
+        grid_tensor, robot_tensor = self._preprocess(grid_numpy, robot_numpy)
+        with torch.no_grad():
+            logits = self.model(grid_tensor, robot_tensor)
+            probs = torch.sigmoid(logits)
+        heatmap = probs.squeeze(0).squeeze(0).cpu().numpy()
+        return heatmap

--- a/tests/unit/dnn_guidance/test_inference.py
+++ b/tests/unit/dnn_guidance/test_inference.py
@@ -1,0 +1,60 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+SRC_PATH = Path(__file__).resolve().parents[3] / "src"
+sys.path.append(str(SRC_PATH))
+
+from dnn_guidance.model import UNetFiLM
+from dnn_guidance.inference import InferenceHandler
+from dnn_guidance.data_loader import RobotParamScaling
+
+
+def _dummy_inputs(size: int = 32):
+    grid = np.zeros((size, size), dtype=np.uint8)
+    grid[0, 0] = 8
+    grid[-1, -1] = 9
+    robot = np.array([2.5, 20.0], dtype=np.float32)
+    return grid, robot
+
+
+def test_predict_with_checkpoint(tmp_path):
+    model = UNetFiLM()
+    ckpt = tmp_path / "model.pth"
+    torch.save(model.state_dict(), ckpt)
+
+    handler = InferenceHandler(UNetFiLM, ckpt, device="cpu")
+
+    grid, robot = _dummy_inputs()
+    pred = handler.predict(grid, robot)
+
+    assert isinstance(pred, np.ndarray)
+    assert pred.shape == grid.shape
+    assert pred.min() >= 0.0 and pred.max() <= 1.0
+
+    scaling = RobotParamScaling()
+    cl, step = scaling.scale(robot[0], robot[1])
+    grid_tensor = torch.from_numpy(
+        np.stack([
+            (grid == 8).astype(np.float32),
+            (grid == 9).astype(np.float32),
+            ((grid == 0) | (grid == 8) | (grid == 9)).astype(np.float32),
+            1.0 - ((grid == 0) | (grid == 8) | (grid == 9)).astype(np.float32),
+        ])
+    ).unsqueeze(0)
+    robot_tensor = torch.tensor([[cl, step]], dtype=torch.float32)
+    model.eval()
+    with torch.no_grad():
+        expected = torch.sigmoid(model(grid_tensor, robot_tensor)).squeeze().numpy()
+    assert np.allclose(pred, expected)
+
+
+def test_predict_without_checkpoint():
+    handler = InferenceHandler(UNetFiLM, None, device="cpu")
+    grid, robot = _dummy_inputs()
+    pred = handler.predict(grid, robot)
+    assert isinstance(pred, np.ndarray)
+    assert pred.shape == grid.shape
+    assert pred.min() >= 0.0 and pred.max() <= 1.0


### PR DESCRIPTION
## Summary
- implement reusable InferenceHandler class for running model inference
- add unit tests covering checkpoint and random-weight inference

## Testing
- `pytest tests/unit/dnn_guidance/test_inference.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e637d7cb4832582e794301f44ead1