### PR TITLE
Implement Navigator skeleton and initial test

### DIFF
--- a/src/hybrid_system/__init__.py
+++ b/src/hybrid_system/__init__.py
@@ -1,0 +1,3 @@
+from .navigator import Navigator, NavigatorState
+
+__all__ = ["Navigator", "NavigatorState"]

--- a/src/hybrid_system/navigator.py
+++ b/src/hybrid_system/navigator.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import List, Tuple, Optional, Any
+
+
+class NavigatorState(Enum):
+    """Enumeration of the Navigator's possible states."""
+
+    IDLE = auto()
+    PLANNING = auto()
+    NAVIGATING = auto()
+    RE_PLANNING = auto()
+    RECOVERY = auto()
+    GOAL_REACHED = auto()
+    FAILED = auto()
+
+
+@dataclass
+class Navigator:
+    """Finite state machine managing global and local planners."""
+
+    global_planner: Any
+    local_planner: Any
+    state: NavigatorState = NavigatorState.IDLE
+    goal: Optional[Tuple[float, float]] = None
+    global_path: List[Tuple[float, float]] = field(default_factory=list)
+
+    def set_goal(self, goal: Tuple[float, float]) -> None:
+        """Assign a new goal and transition to the planning state."""
+        self.goal = tuple(float(v) for v in goal)
+        self.global_path.clear()
+        self.state = NavigatorState.PLANNING
+
+    def tick(self) -> Tuple[float, float]:
+        """Advance the state machine and return a velocity command."""
+        if self.state == NavigatorState.IDLE:
+            return 0.0, 0.0
+        if self.state == NavigatorState.PLANNING:
+            # Placeholder for future global planning logic
+            return 0.0, 0.0
+        if self.state == NavigatorState.NAVIGATING:
+            # Placeholder for future navigation logic
+            return 0.0, 0.0
+        if self.state == NavigatorState.RE_PLANNING:
+            # Placeholder for future re-planning logic
+            return 0.0, 0.0
+        if self.state == NavigatorState.RECOVERY:
+            # Placeholder for future recovery behavior
+            return 0.0, 0.0
+        if self.state == NavigatorState.GOAL_REACHED:
+            return 0.0, 0.0
+        if self.state == NavigatorState.FAILED:
+            return 0.0, 0.0
+        return 0.0, 0.0

--- a/tests/unit/test_navigator.py
+++ b/tests/unit/test_navigator.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import sys
+
+SRC_PATH = Path(__file__).resolve().parents[2] / "src"
+sys.path.append(str(SRC_PATH))
+
+from hybrid_system import Navigator, NavigatorState
+
+
+class DummyPlanner:
+    pass
+
+
+def test_navigator_set_goal_changes_state():
+    nav = Navigator(DummyPlanner(), DummyPlanner())
+    assert nav.state == NavigatorState.IDLE
+    nav.set_goal((1.0, 2.0))
+    assert nav.state == NavigatorState.PLANNING


### PR DESCRIPTION
## Summary
- add Navigator state machine skeleton
- expose Navigator in package
- add unit test ensuring goal transition from IDLE to PLANNING

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68871ba0aba083258ceedd395d56e160